### PR TITLE
added generic error handling

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,3 +107,4 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
+#jam

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,4 +107,3 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
-#jam

--- a/ingest_takeon_data_method.py
+++ b/ingest_takeon_data_method.py
@@ -14,12 +14,14 @@ def lambda_handler(event, context):
     """
     current_module = "Results Data Ingest - Method"
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Results Data Ingest")
     logger.setLevel(10)
+    run_id = 0
     try:
         logger.info("Retrieving data from take on file...")
-
+        # Retrieve run_id before input validation
+        # Because it is used in exception handling
+        run_id = event['RuntimeVariables']['run_id']
         period = event['period']
         periodicity = event['periodicity']
         previous_period = general_functions.calculate_adjacent_periods(period,
@@ -85,28 +87,14 @@ def lambda_handler(event, context):
         logger.info("Successfully extracted data from take on.")
         final_output = {"data": json.dumps(output_json)}
 
-    except KeyError as e:
-        error_message = ("Key Error in "
-                         + current_module + " |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
     except Exception as e:
-        error_message = ("General Error in "
-                         + current_module + " ("
-                         + str(type(e)) + ") |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             return {"success": False, "error": error_message}
 
-    logger.info("Successfully completed method: " + current_module)
-    final_output["success"] = True
+    logger.info("Successfully completed module: " + current_module)
+    final_output['success'] = True
     return final_output

--- a/ingest_takeon_data_wrangler.py
+++ b/ingest_takeon_data_wrangler.py
@@ -3,8 +3,7 @@ import logging
 import os
 
 import boto3
-from botocore.exceptions import ClientError, IncompleteReadError
-from es_aws_functions import aws_functions, exception_classes
+from es_aws_functions import aws_functions, exception_classes, general_functions
 from marshmallow import Schema, fields
 
 
@@ -30,7 +29,6 @@ def lambda_handler(event, context):
     """
     current_module = "Results Data Ingest - Wrangler"
     error_message = ""
-    log_message = ""
     logger = logging.getLogger("Results Data Ingest")
     logger.setLevel(10)
 
@@ -75,7 +73,8 @@ def lambda_handler(event, context):
         payload = {
             "data": json.loads(input_file),
             "period": period,
-            "periodicity": periodicity
+            "periodicity": periodicity,
+            "RuntimeVariables": {"run_id": run_id}
         }
 
         method_return = lambda_client.invoke(
@@ -97,58 +96,12 @@ def lambda_handler(event, context):
 
         aws_functions.send_sns_message(checkpoint, sns_topic_arn, "Ingest.")
 
-    except ClientError as e:
-        error_message = ("AWS Error in ("
-                         + str(e.response["Error"]["Code"]) + ") "
-                         + current_module + " |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id)
-                         + " | Run_id: " + str(run_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except KeyError as e:
-        error_message = ("Key Error in "
-                         + current_module + " |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id)
-                         + " | Run_id: " + str(run_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except IncompleteReadError as e:
-        error_message = ("Incomplete Lambda response encountered in "
-                         + current_module + " |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id)
-                         + " | Run_id: " + str(run_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-
-    except ValueError as e:
-        error_message = ("Blank or empty environment variable in "
-                         + current_module + " |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id)
-                         + " | Run_id: " + str(run_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
-    except exception_classes.MethodFailure as e:
-        error_message = e.error_message
-        log_message = "Error in " + method_name + "."\
-            + " | Run_id: " + str(run_id)
     except Exception as e:
-        error_message = ("General Error in "
-                         + current_module + " ("
-                         + str(type(e)) + ") |- "
-                         + str(e.args) + " | Request ID: "
-                         + str(context.aws_request_id)
-                         + " | Run_id: " + str(run_id))
-
-        log_message = error_message + " | Line: " + str(e.__traceback__.tb_lineno)
+        error_message = general_functions.handle_exception(e, current_module,
+                                                           run_id, context)
     finally:
         if (len(error_message)) > 0:
-            logger.error(log_message)
+            logger.error(error_message)
             raise exception_classes.LambdaFailure(error_message)
 
     logger.info("Successfully completed module: " + current_module)

--- a/tests/test_ingest_takeon_data_method.py
+++ b/tests/test_ingest_takeon_data_method.py
@@ -12,7 +12,8 @@ context_object = MockContext()
 
 payload = {
     "period": "201809",
-    "periodicity": "03"
+    "periodicity": "03",
+    "RuntimeVariables": {"run_id": "o"}
 }
 
 
@@ -58,7 +59,7 @@ class TestIngestTakeOnData():
 
                 assert "success" in response
                 assert response["success"] is False
-                assert """General exception""" in response["error"]
+                assert "'Exception'" in response["error"]
 
     def test_method_key_error(self):
         if "data" in payload:
@@ -68,4 +69,4 @@ class TestIngestTakeOnData():
             payload, context_object
         )
 
-        assert """Key Error""" in returned_value["error"]
+        assert "KeyError" in returned_value["error"]

--- a/tests/test_ingest_takeon_data_wrangler.py
+++ b/tests/test_ingest_takeon_data_wrangler.py
@@ -83,7 +83,7 @@ class TestIngestTakeOnData():
                     runtime_variables, context_object
                 )
 
-            assert "General Error" in exc_info.exception.error_message
+            assert "'Exception'" in exc_info.exception.error_message
 
     def test_missing_env_var(self):
 
@@ -106,10 +106,10 @@ class TestIngestTakeOnData():
                 ingest_takeon_data_wrangler.lambda_handler(
                     {"RuntimeVariables":
                         {"checkpoint": 123, "period": "201809", "run_id": "bob",
-                         "queue_url": "Earl"}},
+                         "queue_url": "Earl", "run_id": "bob"}},
                     context_object,
                 )
-            assert "Blank or empty environment variable in" in \
+            assert "Error validating environment param" in \
                    exc_info.exception.error_message
 
     @mock.patch('ingest_takeon_data_wrangler.aws_functions.send_sns_message')
@@ -130,7 +130,7 @@ class TestIngestTakeOnData():
                 ingest_takeon_data_wrangler.lambda_handler(
                     runtime_variables, context_object
                 )
-            assert "Incomplete Lambda response" in exc_info.exception.error_message
+            assert "IncompleteReadError" in exc_info.exception.error_message
 
     @mock.patch('ingest_takeon_data_wrangler.aws_functions.send_sns_message')
     @mock.patch('ingest_takeon_data_wrangler.boto3.client')
@@ -140,7 +140,7 @@ class TestIngestTakeOnData():
             ingest_takeon_data_wrangler.lambda_handler(
                 runtime_variables, context_object
             )
-        assert "Could not find" in exc_info.exception.error_message
+        assert "ClientError" in exc_info.exception.error_message
 
     @mock.patch("ingest_takeon_data_wrangler.boto3.client")
     @mock.patch("ingest_takeon_data_wrangler.aws_functions.read_from_s3")
@@ -186,4 +186,4 @@ class TestIngestTakeOnData():
                 ingest_takeon_data_wrangler.lambda_handler(
                     runtime_variables, context_object
                 )
-            assert "Key Error" in exc_info.exception.error_message
+            assert "KeyError" in exc_info.exception.error_message


### PR DESCRIPTION
The last module to recieve generic error handling.
Wrangler now sends runid to method for use in error handling.
Didnt need to add to serverless yaml because it already uses the layer.
Will close lu-5463 More logging/error capture