### PR TITLE
Lu 5843 getting variables

### DIFF
--- a/serverless.sh
+++ b/serverless.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cd ingest-deploy-repository
-echo Installing dependancies
+serverless plugin install --name serverless-pseudo-parameters
 serverless plugin install --name serverless-latest-layer-version
 echo Packaging serverless bundle...
 serverless package --package pkg

--- a/serverless.sh
+++ b/serverless.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 cd ingest-deploy-repository
+echo Installing dependencies
 serverless plugin install --name serverless-pseudo-parameters
 serverless plugin install --name serverless-latest-layer-version
 echo Packaging serverless bundle...

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,3 +60,4 @@ functions:
       period: 201809
 plugins:
   - serverless-latest-layer-version
+  - serverless-pseudo-parameters

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,8 +3,8 @@ service: es-ingest-takeon-data
 provider:
   name: aws
   deploymentBucket:
-    name: spp-results-sandbox-serverless
-  role: arn:aws:iam::${self:custom.accountId}:role/lambda_invoke_lambda
+    name: spp-results-${self:custom.environment}-serverless
+  role: arn:aws:iam::#{AWS::AccountId}:role/lambda_invoke_lambda
   vpc:
     securityGroupIds:
       - ${file(../json_outputs/security_groups_output.json):SecurityGroups.0.GroupId}
@@ -21,7 +21,7 @@ provider:
     lambda: true
 
 custom:
-  accountId: ${env:aws_account_id}
+  environment: ${env:ENVIRONMENT}
 
 functions:
   deploy-wrangler:
@@ -33,14 +33,14 @@ functions:
       exclude:
         - ./**
     layers:
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
     environment:
       checkpoint: 0
       method_name: es-ingest-takeon-data-method
-      results_bucket_name: spp-results-sandbox
+      results_bucket_name: spp-results-${self:custom.environment}
       takeon_bucket_name: takeon.validationdb.export.bucket
 
   deploy-method:
@@ -52,8 +52,8 @@ functions:
       exclude:
         - ./**
     layers:
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:es_python_layer:latest
-      - arn:aws:lambda:eu-west-2:${self:custom.accountId}:layer:dev-es-common-functions:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:es_python_layer:latest
+      - arn:aws:lambda:eu-west-2:#{AWS::AccountId}:layer:dev-es-common-functions:latest
     tags:
       app: results
     environment:


### PR DESCRIPTION
This change is so that we dont pull variables out of secrets manager.
uses serverless-pseudo-parameters to get account id
AWS::Account id comes from the account being deployed to and populates when the deploy happens.

Environment and Environment type are passed in from environment variables in the pipeline.

Deployment bucket name now uses environment.(because sandbox bucket contains the word sandbox and integration bucket contains the word integration)

In step functions deploy, wranglers.json is now with the code.

All changes have been tested together in 'test-pipeline-without-secrets' in the new concourse.