### PR TITLE
Added status handling

### DIFF
--- a/ingest_takeon_data_method.py
+++ b/ingest_takeon_data_method.py
@@ -31,6 +31,7 @@ def lambda_handler(event, context):
                                                                        periodicity)
         question_labels = event['RuntimeVariables']['question_labels']
         survey_codes = event['RuntimeVariables']['survey_codes']
+        statuses = event['RuntimeVariables']['statuses']
 
         input_json = event['data']
         output_json = []
@@ -53,9 +54,6 @@ def lambda_handler(event, context):
                         for expected_question in question_labels.keys():
                             out_contrib[question_labels[expected_question]] = 0
 
-                        # will mark if there is at least one actual response
-                        data_provided = False
-
                         # where contributors provided an aswer, use it instead
                         for question in contributor['responsesByReferenceAndPeriodAndSurvey']['nodes']:  # noqa: E501
                             if question['questioncode'] in question_labels.keys() and\
@@ -63,14 +61,12 @@ def lambda_handler(event, context):
                                 out_contrib[question_labels[question['questioncode']]]\
                                     = int(question['response'])
 
-                                # check if response was provided
-                                if int(question['response']) != 0:
-                                    data_provided = True
-
-                        # response type indicator/status to be decided between the teams
-                        # this should work for now
-                        if data_provided:
-                            out_contrib['response_type'] = 2
+                        # convert the response statuses to types,
+                        # used by results to check if imputation should run
+                        # assume all unknown statuses need to be imputed
+                        # (this may change after further cross-team talks)
+                        if contributor['status'] in statuses:
+                            out_contrib['response_type'] = statuses[contributor['status']]
                         else:
                             out_contrib['response_type'] = 1
 

--- a/ingest_takeon_data_wrangler.py
+++ b/ingest_takeon_data_wrangler.py
@@ -78,7 +78,8 @@ def lambda_handler(event, context):
             "RuntimeVariables": {
                 "run_id": run_id,
                 "question_labels": ingestion_parameters["question_labels"],
-                "survey_codes": ingestion_parameters["survey_codes"]
+                "survey_codes": ingestion_parameters["survey_codes"],
+                "statuses": ingestion_parameters["statuses"]
             },
         }
 

--- a/tests/fixtures/test_results_ingest_output.json
+++ b/tests/fixtures/test_results_ingest_output.json
@@ -14,7 +14,7 @@
         "Q606_other_gravel": 299150728,
         "Q607_constructional_fill": 700635557,
         "Q608_total": 620019808,
-        "response_type": 2
+        "response_type": 1
     },
     {
         "survey": "066",
@@ -48,7 +48,7 @@
         "Q606_other_gravel": 360146133,
         "Q607_constructional_fill": 734356718,
         "Q608_total": 924297423,
-        "response_type": 2
+        "response_type": 1
     },
     {
         "survey": "066",
@@ -82,7 +82,7 @@
         "Q606_other_gravel": 212627234,
         "Q607_constructional_fill": 917439796,
         "Q608_total": 732132073,
-        "response_type": 2
+        "response_type": 1
     },
     {
         "survey": "066",
@@ -99,7 +99,7 @@
         "Q606_other_gravel": 418189988,
         "Q607_constructional_fill": 100322514,
         "Q608_total": 113525763,
-        "response_type": 2
+        "response_type": 1
     },
     {
         "survey": "066",
@@ -116,7 +116,7 @@
         "Q606_other_gravel": 252976053,
         "Q607_constructional_fill": 724748877,
         "Q608_total": 64612692,
-        "response_type": 2
+        "response_type": 1
     },
     {
         "survey": "076",
@@ -167,7 +167,7 @@
         "Q606_other_gravel": 0,
         "Q607_constructional_fill": 0,
         "Q608_total": 0,
-        "response_type": 1
+        "response_type": 2
     },
     {
         "survey": "076",
@@ -184,7 +184,7 @@
         "Q606_other_gravel": 0,
         "Q607_constructional_fill": 0,
         "Q608_total": 0,
-        "response_type": 1
+        "response_type": 2
     },
     {
         "survey": "076",

--- a/tests/test_ingest_takeon_data_method.py
+++ b/tests/test_ingest_takeon_data_method.py
@@ -28,6 +28,11 @@ payload = {
         "survey_codes": {
             "0066": "066",
             "0076": "076"
+        },
+        "statuses": {
+            "Form Sent Out": 1,
+            "Clear": 2,
+            "Overridden": 2
         }
     }
 }

--- a/tests/test_ingest_takeon_data_wrangler.py
+++ b/tests/test_ingest_takeon_data_wrangler.py
@@ -25,20 +25,25 @@ runtime_variables = {'RuntimeVariables': {
     "sns_topic_arn": "mock-topic-arn",
     "location": "Here",
     "ingestion_parameters": {
-      "question_labels": {
-        '0601': 'Q601_asphalting_sand',
-        '0602': 'Q602_building_soft_sand',
-        '0603': 'Q603_concreting_sand',
-        '0604': 'Q604_bituminous_gravel',
-        '0605': 'Q605_concreting_gravel',
-        '0606': 'Q606_other_gravel',
-        '0607': 'Q607_constructional_fill',
-        '0608': 'Q608_total'
-      },
-      "survey_codes": {
-        "0066": "066",
-        "0076": "076"
-      }
+        "question_labels": {
+            '0601': 'Q601_asphalting_sand',
+            '0602': 'Q602_building_soft_sand',
+            '0603': 'Q603_concreting_sand',
+            '0604': 'Q604_bituminous_gravel',
+            '0605': 'Q605_concreting_gravel',
+            '0606': 'Q606_other_gravel',
+            '0607': 'Q607_constructional_fill',
+            '0608': 'Q608_total'
+        },
+        "survey_codes": {
+            "0066": "066",
+            "0076": "076"
+        },
+        "statuses": {
+            "Form Sent Out": 1,
+            "Clear": 2,
+            "Overridden": 2
+        }
     }
 }}
 


### PR DESCRIPTION
## Intro
This is a continuation of the [LU-5948: Ingest multi survey support](https://collaborate2.ons.gov.uk/jira/browse/LU-5948) story and completion of the [LU-6111: Properly handle Status and Response_Type](https://collaborate2.ons.gov.uk/jira/browse/LU-6111) sub task.

## Changes
* Replaced old status guesses with new configurable map.
* Added statuses to test configurations.
*  Altered the test file comparison to match the new agreed status standard.
* Cleaned up indentation in a test config.