### PR TITLE
Lu 6530

### DIFF
--- a/ingest_brick_type_method.py
+++ b/ingest_brick_type_method.py
@@ -14,7 +14,7 @@ class RuntimeSchema(Schema):
         logging.error(f"Error validating runtime params: {e}")
         raise ValueError(f"Error validating runtime params: {e}")
 
-    data = fields.Str(required=True)
+    data = fields.List(fields.Dict(required=True))
     brick_questions = fields.Dict(required=True)
     brick_types = fields.List(fields.Int(required=True))
     brick_type_column = fields.Str(required=True)
@@ -48,10 +48,10 @@ def lambda_handler(event, context):
         brick_questions = runtime_variables['brick_questions']
         brick_types = runtime_variables['brick_types']
         brick_type_column = runtime_variables['brick_type_column']
-        data_json = json.loads(runtime_variables['data'])
+        data = runtime_variables['data']
 
         # Apply changes to every responder and every brick type
-        for respondent in data_json:
+        for respondent in data:
             for this_type in brick_types:
 
                 # When it's not the brick type this responder supplied, fill with 0s.
@@ -75,7 +75,7 @@ def lambda_handler(event, context):
                     respondent.pop(this_question, None)
 
         logger.info("Successfully expanded brick data.")
-        final_output = {"data": json.dumps(data_json)}
+        final_output = {"data": json.dumps(data)}
 
     except Exception as e:
         error_message = general_functions.handle_exception(e, current_module,

--- a/ingest_brick_type_wrangler.py
+++ b/ingest_brick_type_wrangler.py
@@ -101,7 +101,7 @@ def lambda_handler(event, context):
                                                                incoming_message_group_id,
                                                                location)
 
-        logger.info("Read from S3.")
+        logger.info("Retrieved data from S3.")
         data_json = data_df.to_json(orient="records")
 
         payload = {

--- a/ingest_brick_type_wrangler.py
+++ b/ingest_brick_type_wrangler.py
@@ -77,12 +77,12 @@ def lambda_handler(event, context):
         runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
         logger.info("Validated parameters.")
 
-        # Environment Variables
+        # Environment Variables.
         checkpoint = environment_variables["checkpoint"]
         method_name = environment_variables["method_name"]
         results_bucket_name = environment_variables["results_bucket_name"]
 
-        # Runtime Variables
+        # Runtime Variables.
         in_file_name = runtime_variables["in_file_name"]
         incoming_message_group_id = runtime_variables["incoming_message_group_id"]
         location = runtime_variables["location"]
@@ -95,7 +95,6 @@ def lambda_handler(event, context):
         logger.info("Validated environment parameters.")
         # Set up client.
         lambda_client = boto3.client("lambda", region_name="eu-west-2")
-
         data_df, receipt_handler = aws_functions.get_dataframe(sqs_queue_url,
                                                                results_bucket_name,
                                                                in_file_name,

--- a/ingest_brick_type_wrangler.py
+++ b/ingest_brick_type_wrangler.py
@@ -107,7 +107,7 @@ def lambda_handler(event, context):
         payload = {
 
             "RuntimeVariables": {
-                "data": data_json,
+                "data": json.loads(data_json),
                 "run_id": run_id,
                 "brick_questions": ingestion_parameters["brick_questions"],
                 "brick_types": ingestion_parameters["brick_types"],

--- a/ingest_takeon_data_wrangler.py
+++ b/ingest_takeon_data_wrangler.py
@@ -24,6 +24,9 @@ class EnvironmentSchema(Schema):
 
 class IngestionParamsSchema(Schema):
 
+    class Meta:
+        unknown = EXCLUDE
+
     question_labels = fields.Dict(required=True)
     survey_codes = fields.Dict(required=True)
     statuses = fields.Dict(required=True)

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,7 +74,7 @@ functions:
       app: results
     environment:
       checkpoint: 0
-      method_name: es-ingest-brick-type-data-method
+      method_name: es-ingest-brick-type-method
       results_bucket_name: spp-results-${self:custom.environment}
 
   deploy-bricks-method:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -23,7 +23,7 @@ wrangler_environment_variables = {
 
 wrangler_runtime_variables_data = {"RuntimeVariables": {
     "run_id": "bob",
-    "in_file_name": "mock-file",
+    "in_file_name": "test_ingest_input.json",
     "out_file_name": "test_wrangler_prepared_output.json",
     "outgoing_message_group_id": "mock_out_group",
     "period": "201809",
@@ -56,9 +56,9 @@ wrangler_runtime_variables_data = {"RuntimeVariables": {
 
 wrangler_runtime_variables_bricks = {"RuntimeVariables": {
     "run_id": "bob",
-    "in_file_name": "mock-file",
+    "in_file_name": "test_bricks_method_input",
     "incoming_message_group_id": "test_group",
-    "out_file_name": "test_wrangler_prepared_output.json",
+    "out_file_name": "test_bricks_wrangler_prepared_output.json",
     "outgoing_message_group_id": "mock_out_group",
     "sns_topic_arn": "mock-topic-arn",
     "queue_url": "mock-sqs-url",
@@ -305,20 +305,24 @@ def test_general_error(which_lambda, which_runtime_variables,
 
 
 @mock_s3
-@mock.patch('ingest_takeon_data_wrangler.aws_functions.read_from_s3',
-            return_value=json.dumps({"test": "test"}))
+@mock.patch('ingest_brick_type_wrangler.aws_functions.get_dataframe',
+            side_effect=test_generic_library.replacement_get_dataframe)
 @pytest.mark.parametrize(
-     "which_method,which_wrangler,which_environment_variables,which_runtime_variables",
+     "which_method,which_wrangler,which_environment_variables,which_runtime_variables," +
+     "which_file_list",
      [
         (lambda_wrangler_function_data, "ingest_takeon_data_wrangler",
-         wrangler_environment_variables, wrangler_runtime_variables_data),
+         wrangler_environment_variables, wrangler_runtime_variables_data,
+         "test_ingest_input.json"),
         (lambda_wrangler_function_bricks, "ingest_brick_type_wrangler",
-         wrangler_environment_variables, wrangler_runtime_variables_bricks)
+         wrangler_environment_variables, wrangler_runtime_variables_bricks,
+         "test_bricks_method_input.json")
      ]
 )
 def test_incomplete_read_error(mock_s3_get, which_method, which_wrangler,
-                               which_environment_variables, which_runtime_variables):
-    file_list = ["test_ingest_input.json"]
+                               which_environment_variables, which_runtime_variables,
+                               which_file_list):
+    file_list = [which_file_list]
     test_generic_library.incomplete_read_error(which_method,
                                                which_runtime_variables,
                                                which_environment_variables,
@@ -346,20 +350,24 @@ def test_key_error(which_lambda, which_environment_variables,
 
 
 @mock_s3
-@mock.patch('ingest_takeon_data_wrangler.aws_functions.read_from_s3',
-            return_value=json.dumps({"test": "test"}))
+@mock.patch('ingest_brick_type_wrangler.aws_functions.get_dataframe',
+            side_effect=test_generic_library.replacement_get_dataframe)
 @pytest.mark.parametrize(
-    "which_method,which_wrangler,which_environment_variables,which_runtime_variables",
+    "which_method,which_wrangler,which_environment_variables,which_runtime_variables," +
+    "which_file_list",
     [
         (lambda_wrangler_function_data, "ingest_takeon_data_wrangler",
-         wrangler_environment_variables, wrangler_runtime_variables_data),
+         wrangler_environment_variables, wrangler_runtime_variables_data,
+         "test_ingest_input.json"),
         (lambda_wrangler_function_bricks, "ingest_brick_type_wrangler",
-         wrangler_environment_variables, wrangler_runtime_variables_bricks)
+         wrangler_environment_variables, wrangler_runtime_variables_bricks,
+         "test_bricks_method_input.json")
     ]
 )
 def test_method_error(mock_s3_get, which_method, which_wrangler,
-                      which_environment_variables, which_runtime_variables):
-    file_list = ["test_ingest_input.json"]
+                      which_environment_variables, which_runtime_variables,
+                      which_file_list):
+    file_list = [which_file_list]
 
     test_generic_library.wrangler_method_error(which_method,
                                                which_runtime_variables,
@@ -507,19 +515,20 @@ def test_wrangler_success_passed(mock_s3_get, which_lambda, input_file, wrangler
 
 
 @mock_s3
-@mock.patch('ingest_takeon_data_wrangler.aws_functions.read_from_s3')
+@mock.patch('ingest_brick_type_wrangler.aws_functions.get_dataframe',
+            side_effect=test_generic_library.replacement_get_dataframe)
 @mock.patch('ingest_takeon_data_wrangler.aws_functions.save_data',
             side_effect=test_generic_library.replacement_save_data)
 @pytest.mark.parametrize(
     "which_lambda,input_file,prepared_method_file,prepared_wrangler_file," +
     "which_environment_variables,which_runtime_variables_wrangler,wrangler_boto3",
     [
-        (lambda_wrangler_function_data, "tests/fixtures/test_ingest_input.json",
+        (lambda_wrangler_function_data, "test_ingest_input.json",
          "tests/fixtures/test_method_prepared_output.json",
          "tests/fixtures/test_wrangler_prepared_output.json",
          wrangler_environment_variables, wrangler_runtime_variables_data,
          "ingest_takeon_data_wrangler.boto3.client"),
-        (lambda_wrangler_function_bricks, "tests/fixtures/test_bricks_method_input.json",
+        (lambda_wrangler_function_bricks, "test_bricks_method_input.json",
          "tests/fixtures/test_bricks_method_prepared_output.json",
          "tests/fixtures/test_bricks_wrangler_prepared_output.json",
          wrangler_environment_variables, wrangler_runtime_variables_bricks,
@@ -535,9 +544,13 @@ def test_wrangler_success_returned(mock_s3_put, mock_s3_get, which_lambda,
     :param None
     :return Test Pass/Fail
     """
-    with open(input_file, "r") as file:
-        wrangler_input = json.dumps(file.read())
-    mock_s3_get.return_value = wrangler_input
+    bucket_name = wrangler_environment_variables["bucket_name"]
+    client = test_generic_library.create_bucket(bucket_name)
+
+    file_list = [input_file]
+
+    test_generic_library.upload_files(client, bucket_name, file_list)
+
     with open(prepared_method_file, "r") as file_2:
         test_data_out = file_2.read()
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -57,10 +57,11 @@ wrangler_runtime_variables_data = {"RuntimeVariables": {
 wrangler_runtime_variables_bricks = {"RuntimeVariables": {
     "run_id": "bob",
     "in_file_name": "mock-file",
+    "incoming_message_group_id": "test_group",
     "out_file_name": "test_wrangler_prepared_output.json",
     "outgoing_message_group_id": "mock_out_group",
     "sns_topic_arn": "mock-topic-arn",
-    "sqs_queue_url": "mock-sqs-url",
+    "queue_url": "mock-sqs-url",
     "location": "Here",
     "ingestion_parameters": {
         "question_labels": {


### PR DESCRIPTION
Following changes were applied to fix the bugs around file loading, data handling and removing questions from non-respondents:
* Changed to use 'queue_url' instead of 'sqs_queue_url' (now matches other modules)
* Added "Exclude" to the og ingest so it runs not carrying about the extra bricks parameters
* Changed how ingest-bricks loads file (to be in line with other more similar modules, as it isn't dealing with a raw take-on data)
* different data format
* handle non-responders
* missed a name in the serverless

Tasks have been adapted to match the changes in logic or methods called.